### PR TITLE
Hapi 2.7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "workshopper": "0.4.x",
     "hyperquest": "0.1.x",
-    "hapi": "1.20.x",
-    "furball": "0.3.3"
+    "hapi": "2.6.x",
+    "furball": "1.0.0"
   },
   "peerDependencies": {},
   "keywords": [

--- a/problems/hello_hapi/problem.txt
+++ b/problems/hello_hapi/problem.txt
@@ -18,8 +18,8 @@ HINT
 
 Create a server that listens on port 8080 with the following code:
 
-var hapi = require('hapi');
-var server = new hapi.Server(8080);
+var Hapi = require('hapi');
+var server = Hapi.createServer('localhost', 8080);
 
 
 Add a route by calling the server route function and passing a route object:

--- a/problems/hello_hapi/solution.js
+++ b/problems/hello_hapi/solution.js
@@ -1,6 +1,10 @@
 var Hapi = require('hapi');
-var server = new Hapi.Server(8081);
-server.route({ method: 'GET', path: '/', handler: function () {
-    this.reply('Hello Hapi');
-}});
+var server = Hapi.createServer('localhost', 8081);
+server.route({
+	method: 'GET',
+	path: '/',
+	handler: function (request, reply) {
+    	reply('Hello Hapi');
+	}
+});
 server.start();

--- a/problems/install_plugin/problem.txt
+++ b/problems/install_plugin/problem.txt
@@ -1,5 +1,5 @@
 Create a hapi server that listens on port 8080 and has the
-furball version 0.3.3 plugin installed and required.
+furball version 1.0.0 plugin installed and required.
 
 
 When you have completed your server, you can run it in the test

--- a/problems/install_plugin/solution.js
+++ b/problems/install_plugin/solution.js
@@ -1,4 +1,4 @@
 var Hapi = require('hapi');
-var server = new Hapi.Server(8081);
+var server = Hapi.createServer('localhost', 8081);
 server.pack.require('furball', function (err) { });
 server.start();

--- a/problems/routing/problem.txt
+++ b/problems/routing/problem.txt
@@ -19,6 +19,6 @@ HINT
 Create a server that listens on port 8080 with a route handler
 similar to the following:
 
-function handler () {
-    this.reply('Hello ' + this.params.name);
+function handler (request, reply) {
+    reply('Hello ' + request.params.name);
 }

--- a/problems/routing/solution.js
+++ b/problems/routing/solution.js
@@ -1,6 +1,10 @@
 var Hapi = require('hapi');
-var server = new Hapi.Server(8081);
-server.route({ method: 'GET', path: '/{name}', handler: function () {
-    this.reply('Hello ' + this.params.name);
-}});
+var server = Hapi.createServer('localhost', 8081);
+server.route({
+	method: 'GET',
+	path: '/{name}',
+	handler: function (request, reply) {
+    	reply('Hello ' + request.params.name);
+	}
+});
 server.start();

--- a/problems/server_options/solution.js
+++ b/problems/server_options/solution.js
@@ -3,6 +3,6 @@ var Hapi = require('hapi');
 var options = {
     debug: { request: ['error', 'uncaught'] }
 };
-var server = new Hapi.Server(8081, options);
+var server = Hapi.createServer('localhost', 8081, options);
 
 server.start();


### PR DESCRIPTION
Hey guys,
I was playing around with Hapi during the last couple of weeks and just saw today that you have a nodeschool-like introduction (nice!) which was still running with the 1.20.x version. I enjoy learning about new feature the nodeschool way so here you go - hapi 2.7 support.
- updated furball and hapi dependency
- updated docs + solutions for hapi 2.x
