### PR TITLE
Use program.js instead of server.js.

### DIFF
--- a/exercises/routes/problem.md
+++ b/exercises/routes/problem.md
@@ -6,11 +6,11 @@ supplied to GET /{name}
 When you have completed your server, you can run it in the test
 environment with:
 
-  {bold}{appname} run server.js{/bold}
+  {bold}{appname} run program.js{/bold}
 
 And once you are ready to verify it then run:
 
-  {bold}{appname} verify server.js{/bold}
+  {bold}{appname} verify program.js{/bold}
 
 -----------------------------------------------------------------
 ##HINTS


### PR DESCRIPTION
The instructions for the Routes exercise tell you to run/verify server.js. However, the instructions provided below by workshopper say to run/verify program.js (e.g. `To verify your program, run: makemehapi verify program.js`). This could be confusing to new users who don't realize this is meant to be the same file. This issue is similar to rvagg/learnyounode#97.
