### PR TITLE
use context parameter in helping exercise

### DIFF
--- a/exercises/helping/problem.md
+++ b/exercises/helping/problem.md
@@ -38,8 +38,8 @@ Each file must export a single method with the signature `function(context)` and
 return a string.
 
 ```
-    return this.query.foo;
 module.exports = function(context) {
+    return context.data.root.query.foo;
 }
 ```
 

--- a/exercises/helping/solution/helpers/helper.js
+++ b/exercises/helping/solution/helpers/helper.js
@@ -1,3 +1,4 @@
 module.exports = function(context) {
-  return this.query.name + this.query.suffix
+    var query = context.data.root.query;
+    return query.name + query.suffix;
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "colors-tmpl": "0.1.0",
     "through2": "^0.4.1",
     "bl": "^0.8.0",
-    "handlebars": "1.3.*",
+    "handlebars": "2.x.x",
     "joi": "4.x.x"
   },
   "peerDependencies": {},


### PR DESCRIPTION
I figure that we should demonstrate using the `context` parameter that is passed in to the helper method. Feel free to close this issue if it really should use `this` instead in this case.

Handlebars v1.3 was causing the context values to be lost somewhere in between the call to renderer in views.js and the helper method. Updating to 2.x.x solved that.
