### PR TITLE
Fix for #92 'Views solution not passing'

### DIFF
--- a/exercises/views/problem.md
+++ b/exercises/views/problem.md
@@ -22,19 +22,18 @@ handler: {
 }
 ```
 
-`createServer` takes an options object as a third parameter. Using this options
-object, you can configure the server to use different templating engines based
-on file extension. You can also define a directory path for templates.
+`server.views()` is the server method that we use to configure the templates
+used on our server. This method receives a configuration object in which we can
+set different engines based on file extension. This object can also set a
+directory path for your templates.
 
 ```js
-var options = {
-    views: {
-        path: 'templates',
-        engines: {
-            html: require('handlebars')
-        }
-    }
-};
+server.views({
+    engines: {
+        html: require('handlebars')
+    },
+    path: Path.join(__dirname, 'templates')
+});
 ```
 
 In this exercise, we'll be using Handlebars. To install handlebars:

--- a/exercises/views/solution/solution.js
+++ b/exercises/views/solution/solution.js
@@ -1,16 +1,14 @@
 var Hapi = require('hapi');
-var path = require('path');
+var Path = require('path');
 
-var options = {
-    views: {
-        path: path.join(__dirname, '/templates'),
-        engines: {
-            html: require('handlebars')
-        }
-    }
-};
+var server = Hapi.createServer('localhost', Number(process.argv[2] || 8080));
 
-var server = Hapi.createServer('localhost', Number(process.argv[2] || 8080), options);
+server.views({
+    engines: {
+        html: require('handlebars')
+    },
+    path: Path.join(__dirname, 'templates')
+});
 
 server.route({
     method: 'GET',
@@ -21,4 +19,3 @@ server.route({
 });
 
 server.start();
-


### PR DESCRIPTION
I changed the solution because the current one is not working. Also changed the reading of the problem so people can use the server.views() method, which is the one we should be using in hapi > 0.7
