### PR TITLE
swap {bold} with __

### DIFF
--- a/exercises/routes/problem.md
+++ b/exercises/routes/problem.md
@@ -7,11 +7,11 @@ supplied to GET /{name}
 When you have completed your server, you can run it in the test
 environment with:
 
-  {bold}{appname} run program.js{/bold}
+  __{appname} run program.js__
 
 And once you are ready to verify it then run:
 
-  {bold}{appname} verify program.js{/bold}
+  __{appname} verify program.js__
 
 -----------------------------------------------------------------
 ##HINTS


### PR DESCRIPTION
I'm assuming the intent in surround text with `{bold}` was to make the text bold, but it's not being formatted as such.

![](https://cldup.com/DqIuI-RJrk-3000x3000.png)

Added in `__` such that the text displays in bold.
